### PR TITLE
feat: print stack traces when using sba.utils.Logger

### DIFF
--- a/plugin/src/main/java/io/github/pronze/sba/utils/Logger.java
+++ b/plugin/src/main/java/io/github/pronze/sba/utils/Logger.java
@@ -40,6 +40,7 @@ public class Logger {
             return;
         }
         instance.logger.info(getMessage(message, params));
+        printStackTraces(params);
     }
     public static void trace(@NonNull String message, Object... params) {
         if (instance.testMode) {
@@ -48,6 +49,7 @@ public class Logger {
         }
         if (instance.level.getLevel() >= Level.TRACE.getLevel()) {
             instance.logger.info(getMessage(message, params));
+            printStackTraces(params);
         }
     }
 
@@ -58,6 +60,7 @@ public class Logger {
         }
         if (instance.level.getLevel() >= Level.WARNING.getLevel()) {
             instance.logger.warning(getMessage(message, params));
+            printStackTraces(params);
         }
     }
 
@@ -68,6 +71,7 @@ public class Logger {
         }
         if (instance.level.getLevel() >= Level.ERROR.getLevel()) {
             instance.logger.severe(getMessage(message, params));
+            printStackTraces(params);
         }
     }
 
@@ -82,6 +86,14 @@ public class Logger {
             message = message.replaceFirst(Pattern.quote("{}"), Matcher.quoteReplacement((String) param));
         }
         return message;
+    }
+
+    private static void printStackTraces(Object... params) {
+        for (var param : params) {
+            if (param instanceof Throwable) {
+                ((Throwable) param).printStackTrace();
+            }
+        }
     }
 
     public static void setMode(Level level) {


### PR DESCRIPTION
Currently Logger does not print stack trace of any passed Throwable. This can make debugging harder in places where Logger#error is used to print the exception as it only prints its name and localized message.