### PR TITLE
fix: player wrapper can re-register immediately after unregistering

### DIFF
--- a/plugin/src/main/java/io/github/pronze/sba/listener/PlayerListener.java
+++ b/plugin/src/main/java/io/github/pronze/sba/listener/PlayerListener.java
@@ -340,7 +340,11 @@ public class PlayerListener implements Listener {
                             .send(party.getMembers().stream().filter(member -> !wrappedPlayer.equals(member))
                                     .toArray(SBAPlayerWrapper[]::new));
                 });
-        SBA.getInstance().getPlayerWrapperService().unregister(player);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void afterPlayerLeave(PlayerQuitEvent event) {
+        SBA.getInstance().getPlayerWrapperService().unregister(event.getPlayer());
     }
 
     @EventHandler


### PR DESCRIPTION
Sometimes the SBAPlayerWrapper can re-register immediately after unregistering in the PlayerQuitEvent, making it impossible for GC to clear the instance. After rejoining, the broken wrapper prevents registering a new one, breaking shop and other features.

This PR delays the wrapper unregistration as much as possible to mitigate this issue.