### PR TITLE
fix: zh-CN is not valid locale

### DIFF
--- a/plugin/src/main/java/io/github/pronze/sba/lib/lang/LanguageService.java
+++ b/plugin/src/main/java/io/github/pronze/sba/lib/lang/LanguageService.java
@@ -29,7 +29,7 @@ public class LanguageService implements ILanguageService {
     private static final List<String> validLocale = List.of(
             "af", "ar", "ca", "cs", "da", "de", "el", "en", "es", "fi", "fr", "he", "hu",
             "it", "ja", "ko", "nl", "no", "pl", "pt", "pt-BR", "ro", "ru", "sr", "sv", "tr",
-            "uk", "vi", "zh", "zh-CN"
+            "uk", "vi", "zh", "zh-cn"
     );
 
     public static LanguageService getInstance() {


### PR DESCRIPTION
Fixes #110 

the input is always lowercased for the comparison, but the list contained entries with uppercase letters